### PR TITLE
Update fc100.md (NeurIPS2022 paper)

### DIFF
--- a/fc100.md
+++ b/fc100.md
@@ -10,6 +10,8 @@ layout: leaderboard
 
 Method   | Venue | Year | Backbone   | Setting | 1-shot      | 5-shot   | Code | Reported by 
 ------- | ------ | ---- | --------   | -----     | -----   | -----    | ---- | ----
+[FewTURE](https://arxiv.org/pdf/2206.07267.pdf) | NeurIPS | 2022 | Swin-Tiny | Inductive | 47.68 ± 0.78 |  63.81 ± 0.75 | [\[PyTorch\]](https://github.com/mrkshllr/FewTURE) | [\[Source\]](https://arxiv.org/pdf/2206.07267.pdf)
+[FewTURE](https://arxiv.org/pdf/2206.07267.pdf) | NeurIPS | 2022 | ViT-Small | Inductive | 46.20 ± 0.79 |  63.14 ± 0.73 | [\[PyTorch\]](https://github.com/mrkshllr/FewTURE) | [\[Source\]](https://arxiv.org/pdf/2206.07267.pdf)
 [HCTransformers](https://arxiv.org/pdf/2203.09064v1.pdf) | CVPR | 2022 | ViT-S | Inductive | 48.27 ± 0.15 | 66.42 ± 0.16 | [\[PyTorch\]](https://github.com/StomachCold/HCTransformers) | [\[Source\]](https://arxiv.org/pdf/2203.09064v1.pdf)
 [EASY](https://arxiv.org/pdf/2201.09699.pdf) | arXiv |  2022 | 2xResNet-12(1/√2) | Transductive |   54.47 ± 0.24 |   65.82 ± 0.19 |  [\[PyTorch\]](https://github.com/ybendou/easy) |  [\[Source\]](https://arxiv.org/pdf/2201.09699.pdf)
 [EASY](https://arxiv.org/pdf/2201.09699.pdf) | arXiv |  2022 | 3xResNet-12 | Transductive |  54.13 ± 0.24 |    66.86 ± 0.19 |  [\[PyTorch\]](https://github.com/ybendou/easy) |  [\[Source\]](https://arxiv.org/pdf/2201.09699.pdf)


### PR DESCRIPTION
Including recent paper accepted at NeurIPS 2022; 
(see https://nips.cc/Conferences/2022/Schedule?showEvent=55167)